### PR TITLE
Use relative paths instead of Pkg.dir()

### DIFF
--- a/src/svgwriter.jl
+++ b/src/svgwriter.jl
@@ -1,5 +1,5 @@
-const snapsvgjs = Pkg.dir("ProfileView", "templates", "snap.svg-min.js")
-const viewerjs = Pkg.dir("ProfileView", "src", "viewer.js")
+const snapsvgjs = joinpath(dirname(@__FILE__), "..", "templates", "snap.svg-min.js")
+const viewerjs = joinpath(dirname(@__FILE__), "viewer.js")
 
 function escape_script(js::String)
     return replace(js, "]]", "] ]")


### PR DESCRIPTION
`Pkg.dir()` won't work if ProfileView is installed outside the standard package location, so use relative paths instead to access other files in the package. See https://github.com/JuliaLang/julia/issues/8679#issuecomment-75796502. This doesn't fix https://github.com/timholy/ProfileView.jl/blob/151c2b3722eaa9d222bbf6910b905c5e5101bdbc/src/ProfileView.jl#L14 which uses Pkg.dir() to access a different package - not sure about what to do there.