### PR TITLE
Support the multi-line backtraces (to handle inlining) on julia-0.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,10 @@ os:
   - linux
 julia:
   - 0.4
+  - nightly
 notifications:
   email: false
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-  - xvfb-run julia --check-bounds=yes -e 'Pkg.clone(pwd()); Pkg.build("ProfileView"); Pkg.test("ProfileView"; coverage=true)'
+  - julia -e 'Pkg.clone(pwd()); Pkg.build("ProfileView")'
+  - xvfb-run julia --check-bounds=yes -e 'Pkg.test("ProfileView"; coverage=true)'

--- a/src/ProfileViewGtk.jl
+++ b/src/ProfileViewGtk.jl
@@ -72,7 +72,14 @@ function viewprof(c, bt, uip, counts, lidict, lkup; C = false, colorgc = true, f
         tag = gettag(xu, yu)
         if tag != ProfileView.TAGNONE
             li = lidict[tag.ip]
-            str = string(basename(string(li.file)), ", ", li.func, ": line ", li.line)
+            if VERSION < v"0.5.0-dev+4192"
+                str = string(basename(string(li.file)), ", ", li.func, ": line ", li.line)
+            else
+                str = ""
+                for l in li
+                    str = string(str, string(basename(string(l.file)), ", ", l.func, ": line ", l.line), "; ")
+                end
+            end
             set_source(ctx, ProfileView.fontcolor)
             Cairo.set_font_face(ctx, "sans-serif $(fontsize)px")
             lasttextbb = deform(Cairo.text(ctx, xu, yu, str, halign = xd < w/3 ? "left" : xd < 2w/3 ? "center" : "right"), -2, 2, -2, 2)
@@ -110,7 +117,19 @@ function viewprof(c, bt, uip, counts, lidict, lkup; C = false, colorgc = true, f
         tag = gettag(xu, yu)
         if tag != ProfileView.TAGNONE
             li = lidict[tag.ip]
-            println(li.file, ", ", li.func, ": line ", li.line)
+            if VERSION < v"0.5.0-dev+4192"
+                println(li.file, ", ", li.func, ": line ", li.line)
+            else
+                firstline = true
+                for l in li
+                    if !firstline
+                        print("  ")
+                    else
+                        firstline = false
+                    end
+                    println(l.file, ", ", l.func, ": line ", l.line)
+                end
+            end
         end
     end
     nothing


### PR DESCRIPTION
julia-0.5 now includes information that makes backtraces sensible in the face of inlining. This PR does its best to make use of this information. For reasons of space, the graphical display is still a bit compressed and doesn't tell the full story, but right-clicking on a bar will dump the multi-line backtrace for that particular statement.