### PR TITLE
Pruning user-specified sub-trees

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ found [below](#gcdetails).
 
 The `view` command has the following syntax:
 ```
-function view(data = Profile.fetch(); lidict = nothing, C = false, colorgc = true, fontsize = 12, combine = true)
+function view(data = Profile.fetch(); lidict = nothing, C = false, colorgc = true, fontsize = 12, combine = true, pruned = [])
 ```
 Here is the meaning of the different arguments:
 
@@ -144,6 +144,8 @@ Here is the meaning of the different arguments:
 - `fontsize` controls the size of the font displayed as a tooltip.
 
 - `combine` is explained [elsewhere](http://docs.julialang.org/en/latest/stdlib/profile/).
+
+- `pruned` is a list of functions (see example) whose call tree will not be displayed. This is useful to control the output of very deep (or recursive) functions. Example: `pruned = [("sort!", "sort.jl"), ("some_function_name", "some_filename.jl")]`
 
 ### Saving profile data manually
 

--- a/src/ProfileViewGtk.jl
+++ b/src/ProfileViewGtk.jl
@@ -42,8 +42,8 @@ function view(data = Profile.fetch(); lidict=nothing, kwargs...)
     showall(win)
 end
 
-function viewprof(c, bt, uip, counts, lidict, lkup; C = false, colorgc = true, fontsize = 12, combine = true)
-    img, lidict, imgtags = ProfileView.prepare_image(bt, uip, counts, lidict, lkup, C, colorgc, combine)
+function viewprof(c, bt, uip, counts, lidict, lkup; C = false, colorgc = true, fontsize = 12, combine = true, pruned=[])
+    img, lidict, imgtags = ProfileView.prepare_image(bt, uip, counts, lidict, lkup, C, colorgc, combine, pruned)
     img24 = UInt32[convert(UInt32, convert(RGB24, img[i,j])) for i = 1:size(img,1), j = size(img,2):-1:1]'
     surf = Cairo.CairoRGBSurface(img24)
     imw = size(img24,2)

--- a/src/ProfileViewSVG.jl
+++ b/src/ProfileViewSVG.jl
@@ -6,8 +6,8 @@ function __init__()
     eval(Expr(:import, :ProfileView))
 end
 
-function view(data = Profile.fetch(); C = false, lidict = nothing, colorgc = true, fontsize = 12, combine = true)
-    img, lidict, imgtags = ProfileView.prepare(data, C=C, lidict=lidict, colorgc=colorgc, combine=combine)
+function view(data = Profile.fetch(); C = false, lidict = nothing, colorgc = true, fontsize = 12, combine = true, pruned = true)
+    img, lidict, imgtags = ProfileView.prepare(data, C=C, lidict=lidict, colorgc=colorgc, combine=combine, pruned=pruned)
     ProfileView.ProfileData(img, lidict, imgtags, fontsize)
 end
 

--- a/src/pvtree.jl
+++ b/src/pvtree.jl
@@ -91,9 +91,13 @@ function setstatus!(parent::Node, isgc::Dict)
 end
 
 # The last three inputs are just for debugging
-function prunegraph!(parent::Node, isjl::Dict, lidict, ip2so, counts)
+function prunegraph!(parent::Node, isjl::Dict, lidict, ip2so, counts,
+                     pruned_set)
     if parent.data.ip != 0 && !isempty(counts)
         counts[ip2so[parent.data.ip]] += 1
+    end
+    if parent.data.ip != 0 && parent.data.ip in pruned_set
+        parent.child = parent
     end
     c = parent.child
     if parent == c
@@ -103,7 +107,7 @@ function prunegraph!(parent::Node, isjl::Dict, lidict, ip2so, counts)
     lastc = c
     isfirst = true
     while true
-        prunegraph!(c, isjl, lidict, ip2so, counts)
+        prunegraph!(c, isjl, lidict, ip2so, counts, pruned_set)
         if !isjl[c.data.ip]
             parent.data.status |= c.data.status
             if !isleaf(c)

--- a/test/pvtree.jl
+++ b/test/pvtree.jl
@@ -39,7 +39,7 @@ end
 # Run it with C == false
 root = buildraw()
 PVTree.setstatus!(root, isgc)
-PVTree.prunegraph!(root, isjl, (), (), ())
+PVTree.prunegraph!(root, isjl, (), (), (), [])
 
 @assert root.data.status == 1
 c = root.child


### PR DESCRIPTION
I found another solution to my problem, which has to do with recursive tree traversal. Without pruning it looks like this:

![screen shot 2016-06-14 at 10 21 37](https://cloud.githubusercontent.com/assets/8622776/16104249/7b380232-334d-11e6-8c2b-5c9489dffcb0.png)

With `pruned = [("build_tree", "regression.jl")]`, only the bottommost `build_tree` is displayed.