### PR TITLE
Updated Cairo version to prevent #90

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,7 +1,7 @@
 julia 0.5
 Gtk
 GtkReactive 0.0.3
-Cairo 0.2.5
+Cairo 0.5.1
 Colors
 Graphics 0.2
 FileIO


### PR DESCRIPTION
Wondering if you would like to make this update to REQUIRE to make sure there are no errors with Cairo (#90).