### PR TITLE
crude fix for view being too wide for jupyter results windows

### DIFF
--- a/src/ProfileView.jl
+++ b/src/ProfileView.jl
@@ -188,7 +188,7 @@ function show(f::IO, ::MIME"image/svg+xml", pd::ProfileData)
 
     ncols, nrows = size(img)
     leftmargin = rightmargin = 10
-    width = 1200
+    width = 1000
     topmargin = 30
     botmargin = 40
     rowheight = 15


### PR DESCRIPTION
`view()` outputs are by default wider than the standard jupyter output windows, which is really frustrating given the odd scrolling behavior. Changing width from 1200 to 1000 fixes this.

I know this is a crude fix, but perhaps it does the job?