### PR TITLE
Add `view(g::Node{NodeData})` to allow displaying FlameGraphs directly

### DIFF
--- a/src/ProfileView.jl
+++ b/src/ProfileView.jl
@@ -84,6 +84,9 @@ end
 # This method allows user to open a *.jlprof file
 view(::Nothing; kwargs...) = view(FlameGraphs.default_colors, Node(NodeData(StackTraces.UNKNOWN, 0, 1:0)); kwargs...)
 
+function view(g::Node{NodeData}; kwargs...)
+    view(FlameGraphs.default_colors, g; kwargs...)
+end
 function view(fcolor, g::Node{NodeData}; data=nothing, lidict=nothing, kwargs...)
     gsig = Signal(g)  # allow substitution by the open dialog
     # Display in a window

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -52,4 +52,10 @@ Profile.clear()
 @profile profile_unstable_test(10, 10^6)
 ProfileView.view()
 
+ProfileView.view(ProfileView.FlameGraphs.flamegraph())
+
+data, lidict = Profile.retrieve()
+ProfileView.view(data, lidict=lidict)
+
+
 ProfileView.closeall()


### PR DESCRIPTION
This adds a method for displaying a `FlameGraph` built via FlameGraphs.jl, directly in `ProfileView`:
```julia
julia> fg = flamegraph()
Node(FlameGraphs.NodeData(ip:0x0, 0x02, 1:1098))

julia> ProfileView.view(fg)
Gtk.GtkWindowLeaf(name="", parent, width-request=-1, height-request=-1, visible=TRUE, sensitive=TRUE, app-paintable=FALSE, can-focus=FALSE, has-focus=FALSE, is-focus=FALSE, focus-on-click=TRUE, can-default=FALSE, has-default=FALSE, receives-default=FALSE, composite-child=FALSE, style, events=0, no-show-all=FALSE, has-tooltip=FALSE, tooltip-markup=NULL, tooltip-text=NULL, window, opacity=1.000000, double-buffered, halign=GTK_ALIGN_FILL, valign=GTK_ALIGN_FILL, margin-left, margin-right, margin-start=0, margin-end=0, margin-top=0, margin-bottom=0, margin=0, hexpand=FALSE, vexpand=FALSE, hexpand-set=FALSE, vexpand-set=FALSE, expand=FALSE, scale-factor=2, border-width=0, resize-mode, child, type=GTK_WINDOW_TOPLEVEL, title="Profile", role=NULL, resizable=TRUE, modal=FALSE, window-position=GTK_WIN_POS_NONE, default-width=800, default-height=600, destroy-with-parent=FALSE, hide-titlebar-when-maximized=FALSE, icon, icon-name=NULL, screen, type-hint=GDK_WINDOW_TYPE_HINT_NORMAL, skip-taskbar-hint=FALSE, skip-pager-hint=FALSE, urgency-hint=FALSE, accept-focus=TRUE, focus-on-map=TRUE, decorated=TRUE, deletable=TRUE, gravity=GDK_GRAVITY_NORTH_WEST, transient-for, attached-to, has-resize-grip, resize-grip-visible, application, is-active=FALSE, has-toplevel-focus=FALSE, startup-id, mnemonics-visible=FALSE, focus-visible=FALSE, is-maximized=FALSE)
```