### PR TITLE
Allow naming the window

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ProfileView"
 uuid = "c46f51b8-102a-5cf2-8d2c-8597cb0e0da7"
 author = ["Tim Holy <tim.holy@gmail.com>"]
-version = "0.6.10"
+version = "0.6.11"
 
 [deps]
 Cairo = "159f3aea-2a34-519c-b102-8c37f9878175"

--- a/src/ProfileView.jl
+++ b/src/ProfileView.jl
@@ -54,7 +54,7 @@ end
 const window_wrefs = WeakKeyDict{Gtk.GtkWindowLeaf,Nothing}()
 
 """
-    ProfileView.view([fcolor], data=Profile.fetch(); lidict=nothing, C=false, recur=:off, fontsize=14, kwargs...)
+    ProfileView.view([fcolor], data=Profile.fetch(); lidict=nothing, C=false, recur=:off, fontsize=14, windowname="Profile", kwargs...)
 
 View profiling results. `data` and `lidict` must be a matched pair from `Profile.retrieve()`.
 You have several options to control the output, of which the major ones are:
@@ -89,7 +89,7 @@ view(::Nothing; kwargs...) = view(FlameGraphs.default_colors, Node(NodeData(Stac
 function view(g::Node{NodeData}; kwargs...)
     view(FlameGraphs.default_colors, g; kwargs...)
 end
-function view(fcolor, g::Node{NodeData}; data=nothing, lidict=nothing, kwargs...)
+function view(fcolor, g::Node{NodeData}; data=nothing, lidict=nothing, windowname="Profile", kwargs...)
     gsig = Signal(g)  # allow substitution by the open dialog
     # Display in a window
     c = canvas(UserUnit)
@@ -106,7 +106,7 @@ function view(fcolor, g::Node{NodeData}; data=nothing, lidict=nothing, kwargs...
     # FIXME: likely have to do `allkwargs` in the two below (add in C, combine, recur)
     signal_connect(open_cb, tb_open, "clicked", Nothing, (), false, (widget(c),gsig,kwargs))
     signal_connect(save_as_cb, tb_save_as, "clicked", Nothing, (), false, (widget(c),data,lidict))
-    win = Window("Profile", 800, 600)
+    win = Window(windowname, 800, 600)
     push!(win, bx)
     GtkReactive.gc_preserve(win, c)
     # Register the window with closeall

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,13 +12,6 @@ function profile_test(n)
     end
 end
 
-function profile_simple_test(n)
-    for i = 1:n
-        A = randn(100,100,20)
-        m = max(A)
-    end
-end
-
 unstable(x) = x > 0.5 ? true : 0.0
 
 function profile_unstable_test(m, n)
@@ -33,6 +26,8 @@ function profile_unstable_test(m, n)
     s, s2
 end
 
+# These tests only ensure that code runs, and does not check the "output"
+
 profile_test(1)
 @profview profile_test(10)
 
@@ -43,12 +38,10 @@ Profile.clear()
 ProfileView.view()
 ProfileView.view(C=true)
 ProfileView.view(fontsize=18)
+ProfileView.view(windowname="ProfileWindow")
 
 Profile.clear()
-@profile profile_unstable_test(1, 1)
-ProfileView.view(ProfileView.FlameGraphs.StackFrameCategory())
-
-Profile.clear()
+profile_unstable_test(1, 1)
 @profile profile_unstable_test(10, 10^6)
 ProfileView.view()
 


### PR DESCRIPTION
If you have many ProfileView windows open at once, this can make it easier to keep track of which is which.