### PR TITLE
Extend test coverage

### DIFF
--- a/src/ProfileView.jl
+++ b/src/ProfileView.jl
@@ -271,7 +271,9 @@ end
 discardfirstcol(A) = A[:,2:end]
 discardfirstcol(A::IndirectArray) = IndirectArray(A.index[:,2:end], A.values)
 
-include("precompile.jl")
-Base.VERSION >= v"1.4.2" && _precompile_()
+if ccall(:jl_generating_output, Cint, ()) == 1
+    include("precompile.jl")
+    _precompile_()
+end
 
 end

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,5 +1,4 @@
 function _precompile_()
-    ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
     stackframe(func, file, line; C=false) = StackFrame(Symbol(func), Symbol(file), line, nothing, C, false, 0)
     backtraces = UInt64[0, 4, 3, 2, 1,   # order: calles then caller
                         0, 6, 5, 1,


### PR DESCRIPTION
This attempts to exclude `precompile` code from coverage analysis, and also picks up a couple of stragglers in the coverage.