### PR TITLE
[do not merge yet] Splat args to avoid MethodError

### DIFF
--- a/src/ProfileView.jl
+++ b/src/ProfileView.jl
@@ -271,7 +271,8 @@ end
 end
 
 function _save(selection, data, lidict)
-    FileIO.save(File{format"JLPROF"}(selection), data, lidict)
+    args = data == nothing && lidict == nothing ? () : (data, lidict)
+    FileIO.save(File{format"JLPROF"}(selection), args...)
     return nothing
 end
 


### PR DESCRIPTION
I'm not familiar with this package, so this PR should probably be looked at carefully. This is an attempted patch fix for #173. The issue I'm seeing is the same `data` and `lidict` are `nothing` which, as far as I know (which is not much regarding the package) is fine. In this case, we hit a method error: 

```
Fatal error:
┌ Warning: Error in @guarded callback
│   exception =
│    MethodError: no method matching save(::FileIO.File{FileIO.DataFormat{:JLPROF}, String}, ::Nothing, ::Nothing)
│    Closest candidates are:
│      save(::FileIO.File{FileIO.DataFormat{:JLPROF}}) at ~/.julia/packages/FlameGraphs/zQEhn/src/io.jl:59
│      save(::FileIO.File{FileIO.DataFormat{:JLPROF}}, ::AbstractVector{<:Unsigned}, ::Dict{UInt64, Vector{Base.StackTraces.StackFrame}}) at ~/.julia/packages/FlameGraphs/zQEhn/src/io.jl:32
│    Stacktrace:
│      [1] invokelatest(::Any, ::Any, ::Vararg{Any}; kwargs::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
│        @ Base ./essentials.jl:716
│      [2] invokelatest(::Any, ::Any, ::Vararg{Any})
│        @ Base ./essentials.jl:714
│      [3] action(::Symbol, ::Vector{Union{Base.PkgId, Module}}, ::FileIO.Formatted, ::Nothing, ::Vararg{Nothing}; options::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
│        @ FileIO ~/dev/FileIO.jl/src/loadsave.jl:219
│      [4] action
│        @ ~/dev/FileIO.jl/src/loadsave.jl:197 [inlined]
│      [5] #save#21
│        @ ~/dev/FileIO.jl/src/loadsave.jl:135 [inlined]
│      [6] save
│        @ ~/dev/FileIO.jl/src/loadsave.jl:132 [inlined]
│      [7] _save
│        @ ~/dev/ProfileView.jl/src/ProfileView.jl:274 [inlined]
│      [8] macro expansion
│        @ ~/dev/ProfileView.jl/src/ProfileView.jl:270 [inlined]
│      [9] save_as_cb(#unused#::Ptr{Gtk.GLib.GObject}, profdata::Tuple{Gtk.GtkCanvas, Nothing, Nothing})
│        @ ProfileView ~/.julia/packages/Gtk/Xtubf/src/base.jl:88
```

I'm assuming that there's good reason, but have not looked into why, `data` and `lidict` are `nothing`. So, my proposed solution here is simply to splat the args into the `FileIO.save` call in order to hit the correct method. I can confirm that, for my particular use case, the file is saved in this PR and this error is thrown in master.

I'm new to using this package, so I'm not even sure yet how to re-open the file to confirm that things look okay. I'll provide updates when I get there, if this isn't merged by then.