### PR TITLE
Redraw the whole image in icicle mode because the text bbox is malformed

### DIFF
--- a/src/ProfileView.jl
+++ b/src/ProfileView.jl
@@ -332,7 +332,10 @@ function viewprof_func(fcolor, c, g, fontsize, zoom_buttons, graphtype)
                 if Graphics.width(lasttextbb[]) > 0
                     r = zr[]
                     set_coordinates(ctx, device_bb(ctx), BoundingBox(r.currentview))
-                    rectangle(ctx, lasttextbb[])
+                    # The bbox returned by deform/Cairo.text below is malformed when the y-axis is inverted
+                    # so redraw the whole screen in :icicle mode
+                    # TODO: Fix the bbox for efficient redraw
+                    rectangle(ctx, graphtype == :icicle ? BoundingBox(r.currentview) : lasttextbb[])
                     set_source(ctx, surf)
                     p = Cairo.get_source(ctx)
                     Cairo.pattern_set_filter(p, Cairo.FILTER_NEAREST)


### PR DESCRIPTION
Just redraws the whole image in icicle mode to work around a bug with the text bbox when the coordinate system is inverted.

I couldn't figure out a fix, so this is a workaround. The window seems just as responsive to me.

___

Issue

![Screenshot from 2022-01-23 02-21-09](https://user-images.githubusercontent.com/1694067/150671004-a9189001-eb0e-4a4e-8f7b-98c06a8c7551.png)

To illustrate with random colors in place of the redraw.
:flame looks good
![Screenshot from 2022-01-23 03-04-44](https://user-images.githubusercontent.com/1694067/150671034-6b8fb9c1-db71-45b2-8bd4-76e37225e6cc.png)

:icicle
![Screenshot from 2022-01-23 03-03-00](https://user-images.githubusercontent.com/1694067/150671040-0bed52ea-b8a3-476b-9ca8-86694003651a.png)
