### PR TITLE
Supply stacktrace to ascend

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ProfileView"
 uuid = "c46f51b8-102a-5cf2-8d2c-8597cb0e0da7"
 author = ["Tim Holy <tim.holy@gmail.com>"]
-version = "1.7.0"
+version = "1.7.1"
 
 [deps]
 Cairo = "159f3aea-2a34-519c-b102-8c37f9878175"


### PR DESCRIPTION
Given a suitably up-to-date Cthulhu, this exploits the stacktrace
(rather than the backedges) to ensure an unbranched set of callers.