### PR TITLE
Migrate from SnoopPrecompile to PrecompileTools

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@ MethodAnalysis = "85b6ec6f-f7df-4429-9514-a64bcd9ee824"
 Preferences = "21216c6a-2e73-6563-6e65-726566657250"
 Profile = "9abbd945-dff8-562f-b5e8-e1ebf5ef1b79"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
-SnoopPrecompile = "66db9d55-30c0-4569-8b51-7e840670fc0c"
+PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
@@ -33,7 +33,7 @@ IntervalSets = "0.2, 0.3, 0.4, 0.5, 0.6, 0.7"
 MethodAnalysis = "0.4"
 Preferences = "1.2"
 Requires = "1"
-SnoopPrecompile = "1"
+PrecompileTools = "1"
 julia = "1.6"
 
 [extras]

--- a/src/ProfileView.jl
+++ b/src/ProfileView.jl
@@ -579,10 +579,10 @@ function __init__()
     end
 end
 
-using SnoopPrecompile
+using PrecompileTools
 
 let
-    @precompile_setup begin
+    @setup_workload begin
         stackframe(func, file, line; C=false) = StackFrame(Symbol(func), Symbol(file), line, nothing, C, false, 0)
 
         backtraces = UInt64[0, 4, 3, 2, 1,   # order: calles then caller
@@ -601,7 +601,7 @@ let
                                         6=>stackframe(:f5, :file3, 1),
                                         7=>stackframe(:f1, :file1, 2),
                                         8=>stackframe(:f6, :file3, 10))
-        @precompile_all_calls begin
+        @compile_workload begin
             g = flamegraph(backtraces; lidict=lidict)
             gdict = Dict(tabname_allthreads => Dict(tabname_alltasks => g))
             win, c, fdraw = viewgui(FlameGraphs.default_colors, gdict)


### PR DESCRIPTION
This pull request migrates the package from [SnoopPrecompile](https://github.com/timholy/SnoopCompile.jl/tree/master/SnoopPrecompile) to [PrecompileTools](https://github.com/JuliaLang/PrecompileTools.jl).
PrecompileTools is **nearly a drop-in replacement** except that there are **changes in naming and how developers locally disable precompilation** (to make their development workflow more efficient). These changes are described in [PrecompileTool's enhanced documentation](https://julialang.github.io/PrecompileTools.jl/stable/), which also includes instructions for users on how to set up custom "Startup" packages, handling precompilation tasks that are not amenable to workloads, and tips for troubleshooting.

Why the new package? It meets several goals:

- The name "SnoopPrecompile" was easily confused with "SnoopCompile," a package designed for *analyzing* rather than *enacting* precompilation.
- SnoopPrecompile/PrecompileTools has become (directly or indirectly) a dependency for much of the Julia ecosystem, a trend that seems likely to grow with time. It makes sense to host it in a more central location than one developer's personal account.
- As Julia's own stdlibs migrate to become independently updateable (true for DelimitedFiles in Julia 1.9, with others anticipated for Julia 1.10), several of them would like to use PrecompileTools for high-quality precompilation. That requires making PrecompileTools its own "upgradable stdlib."
- We wanted to change the [use of Preferences](https://github.com/timholy/SnoopCompile.jl/issues/356) to make packages more independent of one another. Since this would have been a breaking change, it seemed like a good opportunity to fix other issues, too.

For more information and discussion, see this [discourse post](https://discourse.julialang.org/t/ann-snoopprecompile-precompiletools/97882).
