### PR TITLE
avoid precompiling trailing task warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ jobs:
         include:
           - os: ubuntu-latest
             prefix: xvfb-run
+        exclude:
+          - os: windows-latest
+            version: '1.6' # slow registry cloning on CI
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,12 @@ on:
     branches:
       - master
     tags: '*'
+
+# needed to allow julia-actions/cache to delete old caches that it has created
+permissions:
+  actions: write
+  contents: read
+
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
@@ -15,27 +21,18 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        version: ['1.6', '1', 'nightly']
+        version: ['1.6', '1', 'pre']
         arch: [x64]
         include:
           - os: ubuntu-latest
             prefix: xvfb-run
     steps:
       - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v3
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
+      - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
         with:

--- a/src/ProfileView.jl
+++ b/src/ProfileView.jl
@@ -612,6 +612,7 @@ let
             end
             precompile(fdraw)
             closeall()   # necessary to prevent serialization of stale references (including the internal `empty!`)
+            Gtk.enable_eventloop(false, wait_stopped = true) # to avoid trailing task warning
         end
     end
 end


### PR DESCRIPTION
Fixes
```
Precompiling all packages...
  1 dependency successfully precompiled in 5 seconds. 121 already precompiled.
  1 dependency had output during precompilation:
┌ ProfileView
│  [pid 58932] waiting for IO to finish:
│   Handle type        uv_handle_t->data
│   timer              0x60000176cc80->0x111a9e110
│  This means that a package has started a background task or event source that has not finished running. For precompilation to complete successfully, the event source needs to be closed explicitly. See the developer documentation on fixing precompilation hangs for more help.
└ 
```