### PR TITLE
CI updates. Fix for macOS aarch64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,20 +21,15 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        version: ['1.10', '1', 'pre']
-        arch: [x64]
+        version: ['lts', '1', 'pre']
         include:
           - os: ubuntu-latest
             prefix: xvfb-run
-        exclude:
-          - os: windows-latest
-            version: '1.10' # slow registry cloning on CI
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -38,4 +38,4 @@ jobs:
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v5
         with:
-          file: lcov.info
+          files: lcov.info

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -173,7 +173,9 @@ end
         @test_logs (:warn, "click on a non-inlined bar to see `code_warntype` info") warntype_clicked() === nothing
         _, bt = add2(Any[1,2])
         st = stacktrace(bt)
-        ProfileView.clicked[] = st[1]
+        # search for the function because sometimes the first frame is `backtrace()`
+        i = findfirst(sf -> sf.func == :add2, st)
+        ProfileView.clicked[] = st[i]
         io = IOBuffer()
         warntype_clicked(io)
         str = String(take!(io))


### PR DESCRIPTION
- Test macOS aarch64 on apple silicon runners
- Update actions
- Fix macOS aarch64 test failing #244 

Fixes #244 