### PR TITLE
skip precompilation if Gtk4 fails to initialize

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ProfileView"
 uuid = "c46f51b8-102a-5cf2-8d2c-8597cb0e0da7"
 author = ["Tim Holy <tim.holy@gmail.com>"]
-version = "1.9.0"
+version = "1.9.1"
 
 [deps]
 Cairo = "159f3aea-2a34-519c-b102-8c37f9878175"
@@ -34,7 +34,7 @@ Cthulhu = "2"
 FileIO = "1.6"
 FlameGraphs = "0.2.10, 1"
 Graphics = "0.4, 1"
-Gtk4 = "0.5, 0.6, 0.7"
+Gtk4 = "0.7.6"
 GtkObservables = "2"
 InteractiveUtils = "1"
 IntervalSets = "0.2, 0.3, 0.4, 0.5, 0.6, 0.7"

--- a/src/ProfileView.jl
+++ b/src/ProfileView.jl
@@ -568,6 +568,10 @@ function __init__()
             printstyled(io, "\n`using Cthulhu` is required for `$(exc.f)`"; color=:yellow)
         end
     end
+    if !Gtk4.initialized[]
+        error("Gtk4 not initialized")
+        return
+    end
     # by default GtkFrame uses rounded corners
     css="""
         .squared {border-radius: 0;}

--- a/src/ProfileView.jl
+++ b/src/ProfileView.jl
@@ -570,7 +570,6 @@ function __init__()
     end
     if !Gtk4.initialized[]
         error("Gtk4 not initialized")
-        return
     end
     # by default GtkFrame uses rounded corners
     css="""

--- a/src/ProfileView.jl
+++ b/src/ProfileView.jl
@@ -601,6 +601,10 @@ let
         @compile_workload begin
             g = flamegraph(backtraces; lidict=lidict)
             gdict = Dict(tabname_allthreads => Dict(tabname_alltasks => g))
+            if !Gtk4.initialized[]
+                @warn("ProfileView precompile skipped: Gtk4 could not be initialized (are you on a headless system?)")
+                return
+            end
             win, c, fdraw = viewgui(FlameGraphs.default_colors, gdict)
             for obs in c.preserved
                 if isa(obs, Observable) || isa(obs, Observables.ObserverFunction)


### PR DESCRIPTION
Previously, on a headless system ProfileView would fail to precompile because Gtk4 refused to start if the C library's `init_check` method failed. Gtk4 now allows it to fail, but we can't precompile because calling any C library methods without initializing the C library first causes a segmentation fault. With this PR, ProfileView checks if Gtk4 was initialized and skips precompilation if it wasn't. The cost is TTFX if precompilation was done in a headless situation (for example through an SSH connection).

Fixes https://github.com/timholy/ProfileView.jl/issues/219.