### PR TITLE
Handle flamegraphs that use stackframes for other things

### DIFF
--- a/src/ProfileView.jl
+++ b/src/ProfileView.jl
@@ -409,7 +409,13 @@ function viewprof_func(fcolor, c, g, fontsize, tb_items, graphtype)
                 if sf != StackTraces.UNKNOWN
                     str_long = long_info_str(sf)
                     b[String] = str_long
-                    str = string(basename(string(sf.file)), ", ", sf.func, ": line ", sf.line)
+                    str = if sf.file == :none && sf.line == 0
+                        # some flamegraph producers don't provide file/line info as they are not applicable
+                        # The above values together are identifiers for such cases
+                        string(sf.func) # might not actually be a func, just a name
+                    else
+                        string(basename(string(sf.file)), ", ", sf.func, ": line ", sf.line)
+                    end
                     set_source(ctx, fcolor(:font))
                     Cairo.set_font_face(ctx, "sans-serif $(fontsize)px")
                     xi = zr[].currentview.x


### PR DESCRIPTION
https://github.com/KristofferC/TimerOutputs.jl/pull/186 uses FlameGraphs for structures that just have names, not files or line numbers, but it has to go through StackFrames, therefore this special cases the printing to show just the `func` as a label.

This PR

![Screenshot 2025-02-19 at 11 27 21 AM](https://github.com/user-attachments/assets/c11e2a5a-a273-4cc3-b3d8-5c9ada1fd2dd)


Master

![Screenshot 2025-02-19 at 11 28 10 AM](https://github.com/user-attachments/assets/e99894dc-70f4-4d71-9a51-42b7ceb0f4f5)
