### PR TITLE
Use shorter & more standard short info format

### DIFF
--- a/src/ProfileView.jl
+++ b/src/ProfileView.jl
@@ -466,7 +466,7 @@ function short_info_str(sf)
         # The above values together are identifiers for such cases
         string(sf.func) # might not actually be a func, just a name
     else
-        string(basename(string(sf.file)), ":", sf.line, " ", f.func)
+        string(basename(string(sf.file)), ":", sf.line, " ", sf.func)
     end
 end
 

--- a/src/ProfileView.jl
+++ b/src/ProfileView.jl
@@ -409,13 +409,7 @@ function viewprof_func(fcolor, c, g, fontsize, tb_items, graphtype)
                 if sf != StackTraces.UNKNOWN
                     str_long = long_info_str(sf)
                     b[String] = str_long
-                    str = if sf.file == :none && sf.line == 0
-                        # some flamegraph producers don't provide file/line info as they are not applicable
-                        # The above values together are identifiers for such cases
-                        string(sf.func) # might not actually be a func, just a name
-                    else
-                        string(basename(string(sf.file)), ", ", sf.func, ": line ", sf.line)
-                    end
+                    str = short_info_str(sf)
                     set_source(ctx, fcolor(:font))
                     Cairo.set_font_face(ctx, "sans-serif $(fontsize)px")
                     xi = zr[].currentview.x
@@ -463,6 +457,16 @@ function long_info_str(sf)
         string(sf.file, ':', sf.line, ", ", sf.linfo)
     else
         string(sf.file, ':', sf.line, ", ", sf.func, " [inlined]")
+    end
+end
+
+function short_info_str(sf)
+    if sf.file == :none && sf.line == 0
+        # some flamegraph producers don't provide file/line info as they are not applicable
+        # The above values together are identifiers for such cases
+        string(sf.func) # might not actually be a func, just a name
+    else
+        string(basename(string(sf.file)), ", ", sf.func, ": line ", sf.line)
     end
 end
 

--- a/src/ProfileView.jl
+++ b/src/ProfileView.jl
@@ -453,7 +453,11 @@ function viewprof_func(fcolor, c, g, fontsize, tb_items, graphtype)
 end
 
 function long_info_str(sf)
-    if sf.linfo isa Core.MethodInstance
+    if sf.file == :none && sf.line == 0
+        # some flamegraph producers don't provide file/line info as they are not applicable
+        # The above values together are identifiers for such cases
+        string(sf.func) # might not actually be a func, just a name
+    elseif sf.linfo isa Core.MethodInstance
         string(sf.file, ':', sf.line, ", ", sf.linfo)
     else
         string(sf.file, ':', sf.line, ", ", sf.func, " [inlined]")

--- a/src/ProfileView.jl
+++ b/src/ProfileView.jl
@@ -466,7 +466,7 @@ function short_info_str(sf)
         # The above values together are identifiers for such cases
         string(sf.func) # might not actually be a func, just a name
     else
-        string(basename(string(sf.file)), ", ", sf.func, ": line ", sf.line)
+        string(basename(string(sf.file)), ":", sf.line, " ", f.func)
     end
 end
 


### PR DESCRIPTION
Previously
```
file.jl, function_name: line 608
```

here
```
file.jl:608 function_name
```


